### PR TITLE
CM-89 Refactored travis config to run filtered integration tests rather than in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,5 @@ jobs:
             cd ..
             yarn test-install
             echo ">>RUNNING INTEGRATION TESTS<<"
-            yarn test -g "js-client"
+            yarn test -g 'all specifications js-client'
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,5 @@ jobs:
             cd ..
             yarn test-install
             echo ">>RUNNING INTEGRATION TESTS<<"
-            yarn test
+            yarn test -g "js-client"
           fi


### PR DESCRIPTION
-Configuration change in Travis config file which will enable travis to only run integration tests specific to blzjs

-integration tests in test suites blzd/cli will not run anymore when PRs are created in the blzjs repo